### PR TITLE
Bump alpine to 3.5 to support IAM Roles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.4
+FROM alpine:3.5
 
 # Version of RabbitMQ to install
 ENV RABBITMQ_VERSION=3.6.2


### PR DESCRIPTION
As mentioned in https://github.com/aweber/rabbitmq-autocluster/issues/126 IAM Role is not used with alpine:3.4. 